### PR TITLE
Fix database parameter usage and REST routes

### DIFF
--- a/db_connector.py
+++ b/db_connector.py
@@ -33,7 +33,7 @@ def read_records(user_id):
     cursor = connection.cursor()
     query = f"SELECT * FROM mydb.users WHERE user_id = %s"
     print(f"Executing SQL: {query} with user_id: {user_id}")
-    cursor.execute(query, user_id)
+    cursor.execute(query, (user_id,))
     query_result = cursor.fetchone()
     cursor.close()
     connection.close()
@@ -56,7 +56,7 @@ def delete_records(user_id):
     connection = db_connect()
     cursor = connection.cursor()
     query = f"DELETE FROM mydb.users WHERE user_id = %s"
-    cursor.execute(query, user_id)
+    cursor.execute(query, (user_id,))
     connection.commit()
     cursor.close()
     connection.close()

--- a/rest_app.py
+++ b/rest_app.py
@@ -10,7 +10,7 @@ users = {}
 
 @app.route('/stop_server')
 def stop_server():
-    os.kill(os.getpid(), signal.CTRL_C_EVENT)
+    os.kill(os.getpid(), signal.SIGINT)
     return 'Server Stopped'
 
 
@@ -34,12 +34,12 @@ def route_reporter(user_id):
 
 
 # POST method to add users to the database
-@app.route("/add_user/", methods=["POST"])
+@app.route("/add_user/<user_id>", methods=["POST"])
 def user_add(user_id):
     try:
         user_name = request.json.get("user_name")
         if not user_name:
-            raise ValueError("id already exists")
+            raise ValueError("user_name is required")
         db_connector.create_records(int(user_id), str(user_name))
         if user_name:
             return jsonify({"status": "ok", "user_id": user_id, "user_added": user_name}), 200


### PR DESCRIPTION
## Summary
- fix kill signal for rest_app
- include user_id in add_user route and validate param
- use tuples for single-parameter SQL operations

## Testing
- `python -m py_compile rest_app.py db_connector.py web_app.py frontend_testing.py backend_testing.py combined_testing.py clean_environment.py test_api.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6842e681cc3083219f0412d53f6187c6